### PR TITLE
Fix Ocean1_2D_zstar-A configuration

### DIFF
--- a/setup/Ocean1_2D_zstart/A/MOM_override
+++ b/setup/Ocean1_2D_zstart/A/MOM_override
@@ -1,6 +1,12 @@
 ! Blank file in which we can put "overrides" for parameters
 !#override DEBUG_IS = True
 
+! 2D configuration
+ISOMIP_2D = True
+#override SURFACE_PRESSURE_FILE = "Ocean1_2D.nc"
+#override BUOY_CONFIG = "zero"
+#override ICE_THICKNESS_FILE = "Ocean1_2D.nc"
+
 !turn off melting
 #override ICE_SHELF_FLUX_FACTOR = 0.0
 

--- a/setup/common/MOM_input
+++ b/setup/common/MOM_input
@@ -36,10 +36,6 @@ IO_LAYOUT = 1, 1                ! default = 0
 ! === module MOM_grid ===
 
 ! === module MOM_verticalGrid ===
-Z_OUTPUT_GRID_FILE = "ISOMIP_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
 NUM_DIAG_COORDS = 1             ! default = 1
                                 ! The number of diagnostic vertical coordinates to use. For each coordinate, an
                                 ! entry in DIAG_COORDS must be provided.
@@ -86,8 +82,6 @@ DT = 1000.0                      !   [s]
                                 ! is actually used will be an integer fraction of the
                                 ! forcing time-step (DT_FORCING in ocean-only mode or the
                                 ! coupling timestep in coupled mode.)
-DEBUG = False                   !   [Boolean] default = False
-                                ! If true, write out verbose debugging data.
 DT_THERM = 1000.0                !   [s] default = 300.0
                                 ! The thermodynamic and tracer advection time step.
                                 ! Ideally DT_THERM should be an integer multiple of DT
@@ -566,10 +560,6 @@ CONVECTION%
 %CONVECTION
 
 ! === module MOM_entrain_diffusive ===
-CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
                                 ! The maximum number of iterations that may be used to
                                 ! calculate the interior diapycnal entrainment.


### PR DESCRIPTION
The configuration had strong assymetry in the j-direction leading
  to non-zero "v" when this configuration should have zero v.
  This was due to the configuration being out of date w.r.t. a
  recent version of MOM6 but also to some missing parameters in the
  ISOMIP set up.
- Removed obsolete parameters from setup/common/MOM_input
- Add necessary parameters to make 2D configuration behave properly
  in setup/Ocean1_2D_zstart/A/MOM-override

With the above changes this configuration runs as expected although
  the solution is not perfect. At least this corrected configuration
  allows us to analyze the underlying problem with spontaneous motion
  under an iceshelf.

Presumably other 2D configurations will need similar adjustment.